### PR TITLE
Substituição de funções para padrão semelhante ao utilizado no Express

### DIFF
--- a/app/Http/Request.php
+++ b/app/Http/Request.php
@@ -35,6 +35,14 @@
             $this->postVars = (strlen($inputRaw) && empty($_POST)) ? json_decode($inputRaw, true) : $this->postVars;
         }
 
+        public function addPathParams($key, $value) {
+            $this->pathParams[$key] = empty($value) ? null : $value;
+        }
+
+        public function getRouter() {
+            return $this->router;
+        }
+
         public function getHttpMethod() {
             return $this->httpMethod;
         }
@@ -43,27 +51,23 @@
             return $this->uri;
         }
 
-        public function getHeaders() {
-            return $this->headers;
+        public function header($key = false) {
+            if(!$key) return $this->headers;
+            return isset($this->headers[$key]) ? $this->headers[$key] : null;
         }
 
-        public function getQueryParams() {
-            return $this->queryParams;
+        public function body($key = false) {
+            if(!$key) return $this->postVars;
+            return isset($this->postVars[$key]) ? $this->postVars[$key] : null;
         }
 
-        public function getPostVars() {
-            return $this->postVars;
+        public function query($key = false) {
+            if(!$key) return $this->queryParams;
+            return isset($this->queryParams[$key]) ? $this->queryParams[$key] : null;
         }
 
-        public function getPathParams() {
-            return $this->pathParams;
-        }
-
-        public function getRouter() {
-            return $this->router;
-        }
-
-        public function addPathParams($key, $value) {
-            $this->pathParams[$key] = empty($value) ? null : $value;
+        public function param($key = false) {
+            if(!$key) return $this->pathParams;
+            return isset($this->pathParams[$key]) ? $this->pathParams[$key] : null;
         }
     }

--- a/app/Middlewares/Cache.php
+++ b/app/Middlewares/Cache.php
@@ -9,9 +9,9 @@
             if($request->getHttpMethod() != "GET") return false;
 
             if(getenv('ALLOW_NO_CACHE_HEADER') == 'true') {
-                $headers = $request->getHeaders();
+                $cacheControl = $request->header('Cache-Control');
 
-                if(isset($headers['Cache-Control']) && $headers['Cache-Control'] == 'no-cache') return false;
+                if($cacheControl && $cacheControl == 'no-cache') return false;
             }
 
             return true;
@@ -20,7 +20,7 @@
         private function getHash($request) {
             $uri = $request->getRouter()->getUri();
 
-            $queryParams = $request->getQueryParams();
+            $queryParams = $request->query();
             $uri .= !empty($queryParams) ? '?' . http_build_query($queryParams) : '';
             
             return rtrim('route-' . preg_replace('/[^0-9a-zA-Z]/', '-', ltrim($uri, '/')), '-');

--- a/app/Utils/Pagination.php
+++ b/app/Utils/Pagination.php
@@ -51,7 +51,7 @@
             $data = $this->get();
 
             $uri = $request->getUri();
-            $queryParams = $request->getQueryParams();
+            $queryParams = $request->query();
             $href = $uri . '?' . http_build_query(array_merge($queryParams, ['page' => '']));
 
             $defaultComponents = ['number', 'first', 'last', 'previous', 'next', 'ellipsis'];


### PR DESCRIPTION
## Funções para obter parâmetros e outros dados da requisição atualizadas:
- `getHeaders()` -> `header()`;
- `getQueryParams()` -> `query()`;
- `getPostVars()` -> `body()`;
- `getPathParams()` -> `param()`;

Agora também é possível obter um parâmetro específico utilizando o método: `query('id')`.
> As classes `Pagination` e `Cache` foram atualizadas para suportar as atualizações.